### PR TITLE
Perbaiki slider yang menumpuk dengan teks.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -37,7 +37,7 @@ header.masthead h1, header.masthead h2, header.masthead h3 {
   color: white;
 }
 header.masthead .mh-slider {
-  position: relative;
+  position: absolute;
   bottom: 0;
   top: auto;
 }
@@ -1114,7 +1114,6 @@ a:hover {
 }
 
 .ridon-logo {
-	padding-top: 120px;
     padding-bottom: 50px;
 }
 .ridon-text {

--- a/css/styles.css
+++ b/css/styles.css
@@ -37,7 +37,7 @@ header.masthead h1, header.masthead h2, header.masthead h3 {
   color: white;
 }
 header.masthead .mh-slider {
-  position: absolute;
+  position: relative;
   bottom: 0;
   top: auto;
 }

--- a/index.html
+++ b/index.html
@@ -41,9 +41,11 @@
             <div class="slider-container" id="slider">
                 <div class="container">
                     <div class="row mh-container">
-						<img src="img/logo.png" class="ridon-logo">
-						<h4 class="ridon-text"><a href="https://github.com/ridon">Ridon</a> is mobile operating system built on top of <span class="ridon-strikethrough">Replicant</span>, <span class="ridon-strikethrough">CyanogenMod</span>, LineageOS and Android Open Source Project.</h4>
-						<h4 class="ridon-text"><a href="https://github.com/ridon">Ridon</a> is part of <a href="https://www.blankonlinux.or.id/">BlankOn Project</a>.</h4>
+                        <div class="col-md-10 col-md-push-1" id="about">
+                            <img src="img/logo.png" class="ridon-logo">
+                            <h4 class="ridon-text"><a href="https://github.com/ridon">Ridon</a> is mobile operating system built on top of <span class="ridon-strikethrough">Replicant</span>, <span class="ridon-strikethrough">CyanogenMod</span>, LineageOS and Android Open Source Project.</h4>
+                            <h4 class="ridon-text"><a href="https://github.com/ridon">Ridon</a> is part of <a href="https://www.blankonlinux.or.id/">BlankOn Project</a>.</h4>
+                        </div>                        
                         <div class="col-md-10 col-md-push-1 hidden-xs mh-slider">
                             <div class="row">
                                 <div class="col-md-3">

--- a/js/script.js
+++ b/js/script.js
@@ -63,8 +63,13 @@ var appMaster = {
     headerSlider: function(){
 
         var docHeight = $(window).height();
+        var sliderHeight = $('.mh-slider').height();
+        var aboutHeight = $('#about').height();
+        var logoPadding = (docHeight - sliderHeight - aboutHeight);
         
         $("#slider").height(docHeight + "px");
+
+        $("img.ridon-logo").css("padding-top", logoPadding + "px");
 
         $('.mh-container').height(docHeight + "px");
 

--- a/js/script.js
+++ b/js/script.js
@@ -66,6 +66,7 @@ var appMaster = {
         var sliderHeight = $('.mh-slider').height();
         var aboutHeight = $('#about').height();
         var logoPadding = (docHeight - sliderHeight - aboutHeight);
+        if (logoPadding > 120) logoPadding = 120; // 120 is default padding-top on previous version
         
         $("#slider").height(docHeight + "px");
 


### PR DESCRIPTION
Di beberapa ukuran layar, slider bawah akan menumpuk dengan teks di bagian atas, salah satu solusi adalah membuat `padding-top` di `.ridon-logo` menjadi dinamis terhadap tinggi layar dan tinggi konten lain.

**Sebelum**

<img width="1792" alt="screen shot 2017-08-06 at 5 48 50 pm" src="https://user-images.githubusercontent.com/3537856/29002608-924ee1c2-7ad0-11e7-8c6d-b2b3a5087ec1.png">

**Sesudah**

<img width="1792" alt="screen shot 2017-08-06 at 5 48 53 pm" src="https://user-images.githubusercontent.com/3537856/29002611-991b1dc2-7ad0-11e7-9d5e-ef9d8037df71.png">
